### PR TITLE
crazyrealloc.c: force realloc() to move memory around

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Preeny has the following modules:
 | writeout | Some binaries write() to fd 0, expecting it to be a two-way socket. This makes that work (by redirecting to fd 1). |
 | patch | Patches programs at load time. |
 | startstop | Sends SIGSTOP to itself on startup, to suspend the process. |
+| crazyrealloc | ensures that whatever is being reallocated is always moved to a new location in memory, thus free()ing the old. |
 
 ## Building
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,7 @@ desock_dup.so: CFLAGS+=-ldl
 desrand.so: CFLAGS+=-ldl
 deptrace.so: CFLAGS+=-ldl
 mallocwatch.so: CFLAGS+=-ldl
+crazyrealloc.so: CFLAGS+=-ldl
 patch.so: CFLAGS+=-ldl -lini_config
 
 %.so: %.c $(COMMON_DEPS)

--- a/src/crazyrealloc.c
+++ b/src/crazyrealloc.c
@@ -1,0 +1,61 @@
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <dlfcn.h>
+#include "logging.h"
+#include <string.h>
+
+//
+// originals
+//
+void *(*original_malloc)(size_t);
+void (*original_free)(void *);
+void *(*original_realloc)(void *, size_t);
+void *(*original_memcpy)(void *, const void*, size_t);
+__attribute__((constructor)) void preeny_desock_dup_orig()
+{
+	original_malloc = dlsym(RTLD_NEXT, "malloc");
+	original_free = dlsym(RTLD_NEXT, "free");
+	original_realloc = dlsym(RTLD_NEXT, "realloc");
+	original_memcpy = dlsym(RTLD_NEXT, "memcpy");
+}
+
+
+/*
+	The goal of this function is to catch bugs where people
+    assume realloc woudn't move stuff around e.g.
+
+	ptr = malloc(...)
+	realloc(ptr,...) <- ignore return value
+	<use ptr somehow> <- could be double free, use-after-free, etc
+
+	This is attempted by always assuring that realloc returns
+	a new pointer to a new memory area regardless of if the old
+	chunk needed to be moved or not.
+*/
+
+void *realloc(void *ptr, size_t size)
+{
+	void *r = original_realloc(ptr, size);
+	preeny_info("realloc(%p, %d) == %p\n", ptr, size, r);
+
+	if (ptr) {
+
+		void *rm = malloc(size);
+		preeny_info("malloc(%u) == %p\n", size, rm);
+
+		memcpy(rm, r, size);  // if you use ASAN you're gonna
+					   		  // get uninitialized read here
+							  // probably
+		preeny_info("memcpy(%p, %p, %u)\n", rm, r, size);
+		original_free(r);
+		preeny_info("free(%p)\n", r);
+
+		preeny_info("return %p\n", rm);
+		return rm;
+
+	} else {
+		preeny_info("return %p\n", r);
+		return r;
+	}
+}

--- a/src/crazyrealloc.c
+++ b/src/crazyrealloc.c
@@ -38,24 +38,28 @@ void *realloc(void *ptr, size_t size)
 {
 	void *r = original_realloc(ptr, size);
 	preeny_info("realloc(%p, %d) == %p\n", ptr, size, r);
-
-	if (ptr) {
-
-		void *rm = malloc(size);
-		preeny_info("malloc(%u) == %p\n", size, rm);
-
-		memcpy(rm, r, size);  // if you use ASAN you're gonna
-					   		  // get uninitialized read here
-							  // probably
-		preeny_info("memcpy(%p, %p, %u)\n", rm, r, size);
-		original_free(r);
-		preeny_info("free(%p)\n", r);
-
-		preeny_info("return %p\n", rm);
-		return rm;
-
-	} else {
+	if (r != ptr) {
 		preeny_info("return %p\n", r);
 		return r;
+	} else {
+		if (r) {
+
+			void *rm = malloc(size);
+			preeny_info("malloc(%u) == %p\n", size, rm);
+
+			memcpy(rm, r, size);  // if you use ASAN you're gonna
+								  // get uninitialized read here
+								  // probably
+			preeny_info("memcpy(%p, %p, %u)\n", rm, r, size);
+			original_free(r);
+			preeny_info("free(%p)\n", r);
+
+			preeny_info("return %p\n", rm);
+			return rm;
+
+		} else {
+			preeny_info("return %p\n", r);
+			return r;
+		}
 	}
 }

--- a/src/crazyrealloc.c
+++ b/src/crazyrealloc.c
@@ -43,14 +43,12 @@ void *realloc(void *ptr, size_t size)
 		return r;
 	} else {
 		if (r) {
-
 			void *rm = malloc(size);
 			preeny_info("malloc(%u) == %p\n", size, rm);
 
-			memcpy(rm, r, size);  // if you use ASAN you're gonna
-								  // get uninitialized read here
-								  // probably
+			memcpy(rm, r, size);
 			preeny_info("memcpy(%p, %p, %u)\n", rm, r, size);
+
 			original_free(r);
 			preeny_info("free(%p)\n", r);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,11 @@
 .PHONY: all clean
 
-all: sock hello rand
+all: sock hello rand realloc
 
 sock: sock.c
 hello: hello.c
 rand: rand.c
+realloc: realloc.c
 
 clean:
-	rm -f sock hello rand
+	rm -f sock hello rand realloc

--- a/tests/realloc.c
+++ b/tests/realloc.c
@@ -1,0 +1,20 @@
+#include "stdio.h"
+#include <stdlib.h>
+
+/*
+$ PREENY_INFO=1 LD_PRELOAD=../src/crazyrealloc.so ./realloc
+--- realloc(0x1967010, 15) == 0x1967010
+--- malloc(15) == 0x1967030
+--- memcpy(0x1967030, 0x1967010, 15)
+--- free(0x1967010)
+--- return 0x1967030
+*** Error in `./realloc': double free or corruption (fasttop): 0x0000000001967010 ***
+Aborted
+*/
+
+int main()
+{
+	char *s = malloc((size_t)10);
+	realloc(s, (size_t)15);
+	free(s);
+}


### PR DESCRIPTION
People sometimes forget to check the return value of `realloc()`, assuming that there is space after their memory chunks such that expanding is not an issue. However this is not always the case and can lead to double-frees, use-after-frees etc.

Example code:

```c
char *s = malloc((size_t)10);
realloc(s, (size_t)15);
free(s); // <- potential double free 
```

This would result in a double free if `realloc()` moved the memory, and therefore `free()`d `s` afterwards internally before returning execution.

`crazyrealloc.c` ensures that memory is _always_ moved around, such that it's easier to detect bugs as the one described here.