### PR TITLE
decookie.so: Dump stack cookie on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Preeny has the following modules:
 | mallocwatch | When ltrace is inconvenient, mallocwatch provides info on heap operations. |
 | writeout | Some binaries write() to fd 0, expecting it to be a two-way socket. This makes that work (by redirecting to fd 1). |
 | patch | Patches programs at load time. |
+| decookie | Dumps stack canary on startup. |
 | startstop | Sends SIGSTOP to itself on startup, to suspend the process. |
 | crazyrealloc | ensures that whatever is being reallocated is always moved to a new location in memory, thus free()ing the old. |
 

--- a/src/decookie.c
+++ b/src/decookie.c
@@ -55,5 +55,5 @@ canary_t read_canary()
 __attribute__((constructor)) void preeny_cookie_dump()
 {
     preeny_logging_init(); //This haven't been called when we get here so env flags are not respected unless called manually
-	preeny_info(FMT, read_canary());
+    preeny_info(FMT, read_canary());
 }

--- a/src/decookie.c
+++ b/src/decookie.c
@@ -1,0 +1,59 @@
+#define _GNU_SOURCE
+
+#include <inttypes.h>
+
+#include "logging.h"
+
+/**
+ * Copyright (c) 2017 elttam
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifdef __x86_64__
+#define canary_t     uint64_t
+#define INSN_READ    "movq %%fs:0x28, %0;"
+#define FMT          "Found canary: %#lx\n"
+
+#elif __i386__
+#define canary_t     uint32_t
+#define INSN_READ    "movl %%gs:0x14, %0;"
+#define FMT          "Found canary: %#x\n"
+#endif
+
+canary_t read_canary()
+{
+    canary_t val = 0;
+
+    __asm__(INSN_READ
+        : "=r"(val)
+        :
+        :);
+
+    return val;
+}
+
+//
+// Dump stack cookie on startup
+//
+__attribute__((constructor)) void preeny_cookie_dump()
+{
+    preeny_logging_init(); //This haven't been called when we get here so env flags are not respected unless called manually
+	preeny_info(FMT, read_canary());
+}


### PR DESCRIPTION
A new module to dump the generated stack cookie on startup. Good for finding offsets in memory leaks.

Based on this article: https://www.elttam.com.au/blog/playing-with-canaries/
Based on this code: https://github.com/elttam/canary-fun/blob/master/read_canary.c

```
 PREENY_INFO=1 LD_PRELOAD=./x86_64-linux-gnu/decookie.so ./tests/hello 
--- Found canary: 0x2ae8dc00
Hello world!

```