### PR TITLE
Don't recurse mallocwatch on printf

### DIFF
--- a/src/mallocwatch.c
+++ b/src/mallocwatch.c
@@ -4,6 +4,12 @@
 #include <dlfcn.h>
 #include "logging.h"
 
+
+int malloc_hook_active = 1;
+int free_hook_active = 1;
+int calloc_hook_active = 1;
+int realloc_hook_active = 1;
+
 //
 // originals
 //
@@ -11,7 +17,7 @@ void *(*original_malloc)(size_t);
 void (*original_free)(void *);
 void *(*original_calloc)(size_t, size_t);
 void *(*original_realloc)(void *, size_t);
-__attribute__((constructor)) void preeny_desock_dup_orig()
+__attribute__((constructor)) void preeny_mallocwatch_orig()
 {
 	original_malloc = dlsym(RTLD_NEXT, "malloc");
 	original_free = dlsym(RTLD_NEXT, "free");
@@ -22,26 +28,42 @@ __attribute__((constructor)) void preeny_desock_dup_orig()
 void *malloc(size_t size)
 {
 	void *r = original_malloc(size);
-	preeny_info("malloc(%d) == %p\n", size, r);
+	if(malloc_hook_active) {
+		malloc_hook_active = 0;
+		preeny_info("malloc(%d) == %p\n", size, r);
+		malloc_hook_active = 1;
+	}
 	return r;
 }
 
 void free(void *ptr)
 {
 	original_free(ptr);
-	preeny_info("free(%p)\n", ptr);
+	if(free_hook_active) {
+		free_hook_active = 0;
+		preeny_info("free(%p)\n", ptr);
+		free_hook_active = 1;
+	}
 }
 
 void *calloc(size_t nmemb, size_t size)
 {
 	void *r = original_calloc(nmemb, size);
-	preeny_info("calloc(%d, %d) == %p\n", nmemb, size, r);
+	if(calloc_hook_active) {
+		calloc_hook_active = 0;
+		preeny_info("calloc(%d, %d) == %p\n", nmemb, size, r);
+		calloc_hook_active = 1;
+	}
 	return r;
 }
 
 void *realloc(void *ptr, size_t size)
 {
 	void *r = original_realloc(ptr, size);
-	preeny_info("realloc(%p, %d) == %p\n", ptr, size, r);
+	if(realloc_hook_active) {
+		realloc_hook_active = 0;
+		preeny_info("realloc(%p, %d) == %p\n", ptr, size, r);
+		realloc_hook_active = 1;
+	}
 	return r;
 }


### PR DESCRIPTION
printf() calls malloc() internally which means that mallocwatch with info printout creates an infinite recursion. This patch fixes https://github.com/zardus/preeny/issues/45 however this is not a thread safe solution.