### PR TITLE
gitignore: ignore test binaries

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,6 @@
+/hello
+/rand
+/realloc
+/sleep
+/sock
+/uid


### PR DESCRIPTION
Without this gitignore, a simple `make` produced uncommitted changes.