### PR TITLE
Declare preeny_logging_init before using it

### DIFF
--- a/src/getcanary.c
+++ b/src/getcanary.c
@@ -49,6 +49,8 @@ canary_t read_canary()
     return val;
 }
 
+void preeny_logging_init();
+
 //
 // Dump stack cookie on startup
 //


### PR DESCRIPTION
This fixes a warning while building preeny. 