### PR TITLE
Better support for cross-compiling to 32 bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ clean:
 	$(MAKE) -C src clean
 	$(MAKE) -C tests clean
 	rm -rf *-*-*
+
+archinfo:
+	$(MAKE) -C src archinfo

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@
 all: dist tests
 
 dist:
-	make -C src clean
-	make -C src dist
+	$(MAKE) -C src clean
+	$(MAKE) -C src dist
 
 tests:
-	make -C tests
+	$(MAKE) -C tests
 
 clean:
-	make -C src clean
-	make -C tests clean
+	$(MAKE) -C src clean
+	$(MAKE) -C tests clean
 	rm -rf *-*-*

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ It'll create a directory named after the OS and architecture type, then put the 
 
 If you need to build 32-bit x86 preeny libs on a 64-bit x86 host, you can do:
 
-    CFLAGS=-m32 make
+    make ARCH=i386
 
 Alternatively, if you want to utilize a cross-compiler, pass the `CC` variable to `make`.  For example:
 
-    CC=mips-malta-linux-gnu-gcc make -i
+    make -i CC=mips-malta-linux-gnu-gcc
 
 Because some modules fail in cross-complilation, it's recommended to use `make -i`.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,14 +1,39 @@
 .PHONY: all dist clean
 
-PLATFORM?=
+# define defaults for architecture specific variables
+# the target can either be specified by ARCH=i386 for example or by explictly setting a full target
+# triple for example MACHINE=arm-linux-gnueabi
+#
+# the remaining part of the makefile should only care about MACHINE
+CCMACHINE:=$(shell $(CC) -dumpmachine)
+CCARCH=$(firstword $(subst -, ,$(MACHINE)))
+ARCH:=$(firstword $(subst -, ,$(CCMACHINE)))
+# replace ARCH in the target triple (ARCH can be overriden) but only if MACHINE wasn't specified manually
+MACHINE?=$(subst $(firstword $(subst -, ,$(CCMACHINE)))-,$(ARCH)-,$(CCMACHINE))
+ARCH:=$(firstword $(subst -, ,$(MACHINE)))
 
-ifndef MACHINE
-  MACHINE=$(shell $(CC) -dumpmachine)
+# if the only difference between CCMACHINE and MACHINE is 32 vs 64 bit, use -m32
+ifeq ($(ARCH), $(filter $(ARCH), i386 i486 i586 i686 i786 i886 i986))
+  ifeq ($(CCMACHINE), $(subst $(ARCH),x86_64,$(MACHINE)))
+    ARCHFLAGS:=-m32
+  endif
 else
-  ifeq ($(CC),cc)
-    CC=$(MACHINE)-gcc
+ifeq ($(ARCH), ppc)
+  ifeq ($(CCMACHINE), $(subst $(ARCH),ppc64,$(MACHINE)))
+    ARCHFLAGS:=-m32
   endif
 endif
+endif
+
+# set default value for CC if target is not standard target for compiler and we don't have flags to set it
+ifneq ($(MACHINE),$(CCMACHINE))
+ifeq (,$(ARCHFLAGS))
+  CC:=$(MACHINE)-gcc
+else
+  CC:=$(CC) $(ARCHFLAGS)
+endif
+endif
+
 
 ifneq (,$(findstring linux,$(MACHINE)))
   CFLAGS:=$(CFLAGS) -DLINUX -ldl
@@ -48,3 +73,10 @@ dist: all
 clean:
 	rm -f *.o
 	rm -f *.so
+
+archinfo:
+	@echo "Compiler architecture: $(CCARCH)"
+	@echo "Target architecture: $(ARCH)"
+	@echo "Compiler target triple: $(CCMACHINE)"
+	@echo "Computed target triple: $(MACHINE)"
+	@echo "Compiler command: $(CC) $(CFLAGS)"


### PR DESCRIPTION
After these changes, all of the following now work correctly and produce a different target triple (in particular, compiling 32 bit on 64 bit host will put outputs into `i386-pc-linux-gnu`):

```
$ make # compiles normally
$ make -i ARCH=i386 # compiles for 32 bit x86, uses -m32 if host is x86_64
$ make -i CC=aarch64-linux-gnu-gcc # compiles for aarch64
$ make -i MACHINE=aarch64-linux-gnu # same as above
```