### PR TITLE
Enable -Wall and clean up warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,6 +35,8 @@ endif
 endif
 
 
+CFLAGS:=$(CFLAGS) -Wall
+
 ifneq (,$(findstring linux,$(MACHINE)))
   CFLAGS:=$(CFLAGS) -DLINUX -ldl
 else

--- a/src/desock.c
+++ b/src/desock.c
@@ -113,7 +113,6 @@ __attribute__((destructor)) void preeny_desock_shutdown()
 
 void preeny_socket_sync_loop(int from, int to)
 {
-	char error_buf[1024];
 	int r;
 
 	preeny_debug("starting forwarding from %d to %d!\n", from, to);

--- a/src/desock_dup.c
+++ b/src/desock_dup.c
@@ -34,7 +34,7 @@ int close(int sockfd)
 	}
 	else
 	{
-		original_close(sockfd);
+		return original_close(sockfd);
 	}
 }
 
@@ -47,7 +47,7 @@ int dup2(int old, int new)
 	}
 	else
 	{
-		original_dup2(old, new);
+		return original_dup2(old, new);
 	}
 }
 

--- a/src/ensock.c
+++ b/src/ensock.c
@@ -25,7 +25,7 @@ __attribute__((constructor)) void preeny_socketize()
 	int fd = socket(AF_INET, SOCK_STREAM, 0);
 	int conn_fd;
 	struct sockaddr_in serv_addr, client_addr;
-	int client_len = sizeof(client_addr);
+	unsigned int client_len = sizeof(client_addr);
 
 	if (fd < 0)
 	{

--- a/src/eofkiller.c
+++ b/src/eofkiller.c
@@ -94,7 +94,7 @@ int __isoc99_fscanf(FILE *stream, const char *format, ...) {
 }
 
 __attribute__((constructor))
-static void main() {
+int main() {
 	scanf_eof_on_malformed = getenv("SCANF_EOF_ON_MALFORMED") != NULL;
 
 	char *fd_str = getenv("EOF_HOOK_FD");
@@ -102,4 +102,6 @@ static void main() {
 
 	o_vscanf = dlsym(RTLD_NEXT, "vscanf");
 	o_vfscanf = dlsym(RTLD_NEXT, "vfscanf");
+
+	return 0;
 }

--- a/src/patch.c
+++ b/src/patch.c
@@ -101,12 +101,15 @@ int preeny_patch_apply_patch(void *target, void *content, int length)
 	{
 		strerror_r(errno, error_str, 1024);
 		preeny_error("error '%s' making pages containing %d bytes at %p writeable\n", error_str, length, target);
+		return error;
 	}
 
 	preeny_debug("writing %d bytes at %p\n", length, target);
 	memcpy(target, content, length);
 
 	preeny_debug("wrote %d bytes at %p\n", length, target);
+
+	return 0;
 }
 
 int preeny_patch_apply_file(char *conf_file, struct collection_item *patch)
@@ -149,6 +152,8 @@ int preeny_patch_apply_file(char *conf_file, struct collection_item *patch)
 		free(content);
 		if (error > 0) { preeny_error("error applying patch section %s from %s\n", section, conf_file); return -1; }
 	}
+
+	return 0;
 }
 
 __attribute__((constructor)) void preeny_patch_program()

--- a/tests/realloc.c
+++ b/tests/realloc.c
@@ -15,6 +15,9 @@ Aborted
 int main()
 {
 	char *s = malloc((size_t)10);
-	realloc(s, (size_t)15);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+	realloc(s, (size_t)15); // ignore return value. s might be invalidated by this call.
+#pragma GCC diagnostic pop
 	free(s);
 }


### PR DESCRIPTION
This enables and fixes some _essential_ warnings like `Wreturn-type`.
With this commit `preeny` should still build without warnings.