### PR TITLE
Adding ARM support for getcanary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ preeny's patch functionality uses `libini_config` to read `.ini` files.
 * On Arch-based distros, you can install `ding-libs`.
 * On Fedora-based distros, you can install `libini_config-devel`.
 
+Also deexec uses `seccomp` to setup a filter to blacklist `execve` like calls.
+
+* On debian-based distros, you can install `libseccomp-dev`.
+* On Arch-based distros, you can install `libseccomp`.
+* On Fedora-based distros, you can install `libseccomp-devel`.
+
 If you're not running a debian, Arch, or Fedora based distro, you've brought the pain upon yourself.
 
 You can build preeny by doing:
@@ -147,9 +153,9 @@ Patches are specified in a `.ini` format, and applied by including `patch.so` in
 For example:
 
 ```ShellSession
-# tests/hello 
+# tests/hello
 Hello world!
-# cat hello.p 
+# cat hello.p
 [hello]
 address=0x4005c4
 content='4141414141'
@@ -157,7 +163,7 @@ content='4141414141'
 [world]
 address=0x4005ca
 content='6161616161'
-# PATCH="hello.p" LD_PRELOAD=x86_64-linux-gnu/patch.so tests/hello 
+# PATCH="hello.p" LD_PRELOAD=x86_64-linux-gnu/patch.so tests/hello
 --- section hello in file hello.p specifies 5-byte patch at 0x4005c4
 --- section world in file hello.p specifies 5-byte patch at 0x4005ca
 AAAAA aaaaa!

--- a/src/getcanary.c
+++ b/src/getcanary.c
@@ -35,6 +35,11 @@
 #define canary_t     uint32_t
 #define INSN_READ    "movl %%gs:0x14, %0;"
 #define FMT          "Found canary: %#x\n"
+
+#elif __arm__
+#define canary_t     uint32_t
+#define INSN_READ    "ldr r0, =__stack_chk_guard; ldr r0, [r0]; mov %0, r0;"
+#define FMT          "Found canary: %#x\n"
 #endif
 
 canary_t read_canary()

--- a/src/setcanary.c
+++ b/src/setcanary.c
@@ -2,6 +2,19 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifdef __x86_64__
+#define TONUMBER     strtoull
+#define INSN_LOAD    "mov rax, %0;"
+#define INSN_WRITE   "mov QWORD PTR fs:0x28, rax;"
+#define REG          "%rax"
+
+#elif __i386__
+#define TONUMBER     strtoul
+#define INSN_LOAD    "mov eax, %0;"
+#define INSN_WRITE   "mov DWORD PTR gs:0x14, eax;"
+#define REG          "%eax"
+#endif
+
 __attribute__((constructor)) int preeny_set_canary()
 {
 	char *new_canary_str = getenv("CANARY");
@@ -10,16 +23,16 @@ __attribute__((constructor)) int preeny_set_canary()
 		preeny_error("CANARY environment variable not specified. Aborting setcanary.\n");
 		return 0;
 	}
-	uintptr_t new_canary = strtoull(new_canary_str, NULL, 0);
+	uintptr_t new_canary = TONUMBER(new_canary_str, NULL, 0);
 	preeny_debug("Overwriting canary with %#x...\n", new_canary);
 	__asm__ __volatile__ (
 		".intel_syntax noprefix;"
-		"mov rax, %0;"
-		"mov QWORD PTR fs:0x28, rax;"
+		INSN_LOAD
+		INSN_WRITE
 		".att_syntax;"
 		:
 		: "r"(new_canary)
-		: "%rax"
+        : REG
 	);
 	return 0;
 }


### PR DESCRIPTION
As discussed in #54 
Stack canary is stored at `__stack_chk_guard` in arm. A simple load should do the trick.

Also fixing #56 by adding `libseccomp` dependency in README