### PR TITLE
Adding support for arm in setcanary

### DIFF
--- a/src/setcanary.c
+++ b/src/setcanary.c
@@ -4,16 +4,23 @@
 
 #ifdef __x86_64__
 #define TONUMBER     strtoull
-#define INSN_LOAD    "mov rax, %0;"
-#define INSN_WRITE   "mov QWORD PTR fs:0x28, rax;"
+#define INSN_LOAD    "mov %0, %%rax;"
+#define INSN_WRITE   "movq %%rax, %%fs:0x28;"
 #define REG          "%rax"
 
 #elif __i386__
 #define TONUMBER     strtoul
-#define INSN_LOAD    "mov eax, %0;"
-#define INSN_WRITE   "mov DWORD PTR gs:0x14, eax;"
+#define INSN_LOAD    "mov %0, %%eax;"
+#define INSN_WRITE   "movl %%eax, %%gs:0x14;"
 #define REG          "%eax"
+
+#elif __arm__
+#define TONUMBER     strtoul
+#define INSN_LOAD    "mov r4, %0;"
+#define INSN_WRITE   "ldr r0, =__stack_chk_guard; mov r3, r0; ldr r1, =#0xfff; bic r0, r0, r1; mov r1, #0x1000; mov r2, #0x3; mov r7, #0x7d; svc 0; str r4, [r3]; ldr r0, =__stack_chk_guard; mov r3, r0; ldr r1, =#0xfff; bic r0, r0, r1; mov r1, #0x1000; mov r2, #0x1; mov r7, #0x7d; svc 0;"
+#define REG          "r0", "r1", "r3", "r4", "r7"
 #endif
+
 
 __attribute__((constructor)) int preeny_set_canary()
 {
@@ -26,10 +33,8 @@ __attribute__((constructor)) int preeny_set_canary()
 	uintptr_t new_canary = TONUMBER(new_canary_str, NULL, 0);
 	preeny_debug("Overwriting canary with %#x...\n", new_canary);
 	__asm__ __volatile__ (
-		".intel_syntax noprefix;"
 		INSN_LOAD
 		INSN_WRITE
-		".att_syntax;"
 		:
 		: "r"(new_canary)
         : REG


### PR DESCRIPTION
As discussed in #54 I have added support for arm in setcanary. I have tested it on a raspberry pi.
```bash
pi@exos-pi:~ $ head -n 40 z.c
#include <stdio.h>
#include <stdint.h>

#ifdef __x86_64__
#define canary_t     uint64_t
#define INSN_READ    "movq %%fs:0x28, %0;"
#define FMT          "Found canary: %#lx\n"

#elif __i386__
#define canary_t     uint32_t
#define INSN_READ    "movl %%gs:0x14, %0;"
#define FMT          "Found canary: %#x\n"

#elif __arm__
#define canary_t     uint32_t
#define INSN_READ    "ldr r0, =__stack_chk_guard; ldr r0, [r0]; mov %0, r0;"
#define FMT          "Found canary: %#x\n"
#endif

canary_t read_canary()
{
    canary_t val = 0;

    __asm__(INSN_READ
        : "=r"(val)
        :
        :);

    return val;
}

int main(int argc, char **argv)
{
    printf(FMT, read_canary());
    return 0;
}

pi@exos-pi:~ $ gcc -no-pie -fno-pic z.c -o z
pi@exos-pi:~ $ PREENY_DEBUG=1 PREENY_INFO=1 PREENY_ERROR=1 CANARY=1094795585 LD_PRELOAD=~/preeny/build/lib/libsetcanary.so:~/preeny/build/lib/libgetcanary.so ./z
--- Found canary: 0xe14d2500
+++ Overwriting canary with 0x41414141...
Found canary: 0x41414141
```

As for arm64, it still needs some testing. I'll do it in some time.