### PR TITLE
Adding check if dlsym was called before calling malloc+free family.

### DIFF
--- a/src/mallocwatch.c
+++ b/src/mallocwatch.c
@@ -27,6 +27,9 @@ __attribute__((constructor)) void preeny_mallocwatch_orig()
 
 void *malloc(size_t size)
 {
+    if(!original_malloc)
+        preeny_mallocwatch_orig();
+
 	void *r = original_malloc(size);
 	if(malloc_hook_active) {
 		malloc_hook_active = 0;
@@ -38,6 +41,9 @@ void *malloc(size_t size)
 
 void free(void *ptr)
 {
+    if(!original_free)
+        preeny_mallocwatch_orig();
+
 	original_free(ptr);
 	if(free_hook_active) {
 		free_hook_active = 0;
@@ -48,6 +54,9 @@ void free(void *ptr)
 
 void *calloc(size_t nmemb, size_t size)
 {
+    if(!original_calloc)
+        preeny_mallocwatch_orig();
+
 	void *r = original_calloc(nmemb, size);
 	if(calloc_hook_active) {
 		calloc_hook_active = 0;
@@ -59,6 +68,9 @@ void *calloc(size_t nmemb, size_t size)
 
 void *realloc(void *ptr, size_t size)
 {
+    if(!original_realloc)
+        preeny_mallocwatch_orig();
+
 	void *r = original_realloc(ptr, size);
 	if(realloc_hook_active) {
 		realloc_hook_active = 0;


### PR DESCRIPTION
Fixes #59

Verify if `original_malloc` was actually resolved before calling it. If not, just call `preeny_mallocwatch_orig` to get it resolved. Technically `free` and `realloc` would never be called in a scenario like that but added just in case.