### PR TITLE
Fix compilation warning

### DIFF
--- a/test/time.c
+++ b/test/time.c
@@ -8,7 +8,7 @@
 
 int main()
 {
-	printf("Time: %d\n", time(0));
+	printf("Time: %ld\n", time(0));
 #ifdef __unix__
     struct timeval tv;
     struct timezone tz;


### PR DESCRIPTION
GCC 9 was complaining with the following
```
time.c: In function ‘main’:
time.c:11:17: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘time_t’ {aka ‘long int’} [-Wformat=]
   11 |  printf("Time: %d\n", time(0));
      |                ~^     ~~~~~~~
      |                 |     |
      |                 int   time_t {aka long int}
      |                %ld
```