### PR TITLE
detime: remove a dummy arg

### DIFF
--- a/src/detime.c
+++ b/src/detime.c
@@ -38,7 +38,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
 		tz->tz_minuteswest = minwest_str ? atoi(minwest_str) : 0;
 		tz->tz_dsttime = dst_str ? atoi(dst_str) : 0;
 
-		preeny_debug("gettimeofday tz frozen at -%d minm, DST: %d\n", tz->tz_minuteswest, tv->tv_usec, tz->tz_dsttime);
+		preeny_debug("gettimeofday tz frozen at -%d minm, DST: %d\n", tz->tz_minuteswest, tz->tz_dsttime);
 	}
 
 	return 0;


### PR DESCRIPTION
There's a dummy `tv->tv_usec` arg while a call to `preeny_debug`