### PR TITLE
setstdin a library that allow to provide binary with alternative STDIN data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ target_link_libraries(getcanary common-preeny dl)
 add_library(setcanary SHARED src/setcanary.c)
 target_link_libraries(setcanary common-preeny dl)
 
+# SetSTDIN
+add_library(setstdin SHARED src/setstdin.c)
+target_link_libraries(setstdin common-preeny dl)
+
+
 # Tests
 add_executable(test_hello test/hello.c)
 add_executable(test_rand test/rand.c)
@@ -80,6 +85,11 @@ add_executable(test_realloc test/realloc.c)
 add_executable(test_sleep test/sleep.c)
 add_executable(test_sock test/sock.c)
 add_executable(test_uid test/uid.c)
+add_executable(test_setstdin_read  test/setstdin_read.c)
+add_executable(test_setstdin_fread test/setstdin_fread.c)
+add_executable(test_setstdin_getc  test/setstdin_getc.c)
+
+
 
 # Scripts
 file(COPY ${CMAKE_SOURCE_DIR}/test/run_tests.sh DESTINATION ${CMAKE_BINARY_DIR})

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Preeny has the following modules:
 | eofkiller | Exit on EOF on several read functions |
 | getcanary | Dumps the canary on program startup (x86 and amd64 only at the moment). |
 | setcanary | Overwrites the canary with a user-provided one on program startup (amd64-only at the moment). |
+| setstdin  | Sets user defined STDIN data instead of real one, overriding `read`, `fread`, `fgetc`, `getc` and `getchar` calls. Read [here](#STDIN_substitution) for more info |
 
 ## Building
 
@@ -171,3 +172,24 @@ AAAAA aaaaa!
 ```
 
 Having different patch files and just enabling/disabling them via preload is oftentimes easier than modifying the underlying binary.
+
+## STDIN substitution
+
+`setstdin.so` allows to replace `STDIN` with user defined data. It overrides `read`, `fread`, `fgetc`, `getc` and `getchar` calls, and
+return user defined data when binary asks for some `STDIN`.
+
+`setstdin` first tries to get user defined data form `PREENY_STDIN` environment variabe, if this variable is not defined, it tries to read data
+from file, defined in `PREENY_STDIN_FILENAME` environment variable. If both are not defined, `setstdin` uses some default value.
+
+```ShellSession
+$PREENY_STDIN=New_message LD_PRELOAD=src/setstdin.so test/setstdin_read
+N|ew|_me|ssag|e|
+
+$ echo "Some other message" > tmp_file
+$ PREENY_STDIN_FILENAME=tmp_file LD_PRELOAD=src/setstdin.so test/setstdin_getc
+S|o|m|e| |o|t|h|e|r| |m|e|s|s|a|g|e|
+
+$ LD_PRELOAD=src/setstdin.so test/setstdin_fread
+D|ef|aul|t se|tstdi|n valu|e. Plea|se set P|REENY_STD|IN or PREE|NY_STDIN_FI|LENAME envir|onment variab|les to set you|r own value
+
+```

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ return user defined data when binary asks for some `STDIN`.
 from file, defined in `PREENY_STDIN_FILENAME` environment variable. If both are not defined, `setstdin` uses some default value.
 
 ```ShellSession
-$PREENY_STDIN=New_message LD_PRELOAD=src/setstdin.so test/setstdin_read
+$ PREENY_STDIN=New_message LD_PRELOAD=src/setstdin.so test/setstdin_read
 N|ew|_me|ssag|e|
 
 $ echo "Some other message" > tmp_file

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Preeny has the following modules:
 | eofkiller | Exit on EOF on several read functions |
 | getcanary | Dumps the canary on program startup (x86 and amd64 only at the moment). |
 | setcanary | Overwrites the canary with a user-provided one on program startup (amd64-only at the moment). |
-| setstdin  | Sets user defined STDIN data instead of real one, overriding `read`, `fread`, `fgetc`, `getc` and `getchar` calls. Read [here](#STDIN_substitution) for more info |
+| setstdin  | Sets user defined STDIN data instead of real one, overriding `read`, `fread`, `fgetc`, `getc` and `getchar` calls. Read [here](#stdin_substitution) for more info |
 
 ## Building
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,6 +65,7 @@ mallocwatch.so: CFLAGS+=-ldl
 crazyrealloc.so: CFLAGS+=-ldl
 patch.so: CFLAGS+=-ldl -lini_config
 eofkiller.so: CFLAGS+=-ldl
+setstdin.so: CFLAGS+=-ldl
 
 %.so: %.c $(COMMON_DEPS)
 	$(CC) $^ -o $@ -shared -fPIC $(CFLAGS)

--- a/src/setstdin.c
+++ b/src/setstdin.c
@@ -1,0 +1,120 @@
+#define _GNU_SOURCE
+
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+/*#include <unistd.h>*/
+#define STDIN_FILENO 0
+/* This should be better taken from unistd.h, but if you include it, you will get
+conflict with read function declaration. I do not know how to fix it */
+
+int (*original_fgetc)( FILE *stream );
+size_t (*original_read)(int fd, void *data, size_t size);
+size_t (*original_fread)(void *buffer, size_t size, size_t count, FILE *stream);
+
+
+char default_stdin_data[] = "Default setstdin value. Please set PREENY_STDIN or PREENY_STDIN_FILENAME environment variables to set your own value\n";
+char *set_stdin_data = NULL;
+
+__attribute__((constructor)) void preeny_setstdin_dup_orig()
+{
+	original_read = dlsym(RTLD_NEXT, "read");
+	original_fgetc = dlsym(RTLD_NEXT, "fgetc");
+	original_fread = dlsym(RTLD_NEXT, "fread");
+
+	/* Trying to get new STDIN content from environment variable */
+	set_stdin_data = getenv("PREENY_STDIN");
+
+	/* Trying to det new STDIN content from */
+	if (! set_stdin_data)
+	{
+		char *file_name = getenv("PREENY_STDIN_FILENAME");
+		if (file_name)
+		{
+			FILE *f;
+			size_t len;
+			f = fopen(file_name,"r");
+			if(f == NULL)
+			{
+				fprintf(stderr, "Error opening file '%s': %s\n", file_name, strerror(errno));
+				exit(EXIT_FAILURE);
+			}
+			/* Getting file size */
+			fseek(f, 0L, SEEK_END);
+			len = ftell(f);
+			fseek(f, 0L, SEEK_SET);
+			set_stdin_data = malloc(len + 1);
+			if(f == NULL)
+			{
+				fprintf(stderr, "Out of memory\n");
+				exit(EXIT_FAILURE);
+			}
+			if (fread(set_stdin_data, 1, len, f) !=len )
+			{
+				fprintf(stderr, "Error reading file '%s'\n",file_name);
+				exit(EXIT_FAILURE);
+			}
+			set_stdin_data[len] = '\0'; /* Make 0-terminated string out of it */
+		}
+	}
+	/* If no data for stdin were provided use default sample data */
+	if (! set_stdin_data)
+		set_stdin_data = default_stdin_data;
+}
+
+int getchar()
+{
+	int res;
+	if (set_stdin_data[0] == '\0')
+		return EOF;
+	res = set_stdin_data[0];
+	set_stdin_data++;
+	return res;
+}
+
+int fgetc( FILE *stream )
+{
+	if (fileno(stream) != STDIN_FILENO)
+		return original_fgetc(stream);
+	return getchar();
+}
+
+int getc( FILE *stream )
+{
+	return fgetc(stream);
+}
+
+size_t read(int fd, void *data, size_t size)
+{
+	int len;
+	/* If read from non-stdin file descriptor, just use original function*/
+	if (fd != STDIN_FILENO)
+		return original_read(fd, data, size);
+	/* If set_stdin_data points to the end of line, return nothing*/
+	if (set_stdin_data[0] == '\0')
+		return 0;
+	len = strlen(set_stdin_data);
+	/* If requested size is less then set_stdin_data length, copy requested data */
+        /* to the output, and move set_stdin_data to unused data */
+	if (strlen(set_stdin_data) > size)
+	{
+		memcpy(data, set_stdin_data, size);
+		set_stdin_data += size;
+		return size;
+	}
+	/* If size is bigger then set_stdin_data length, return what we have and */
+	/* move set_stdin_data to the very end of the string */
+	memcpy(data, set_stdin_data, len);
+	set_stdin_data += len;
+	return len;
+}
+
+size_t fread(void *buffer, size_t size, size_t count, FILE *stream)
+{
+	if (fileno(stream) != STDIN_FILENO)
+		return original_fread(buffer, size, count, stream);
+	return read(STDIN_FILENO, buffer, size * count);
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-all: sock hello rand realloc uid sleep time
+all: sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read
 
 sock: sock.c
 hello: hello.c
@@ -9,6 +9,9 @@ realloc: realloc.c
 uid: uid.c
 sleep: sleep.c
 time: time.c
+setstdin_fread: setstdin_fread.c
+setstdin_getc: setstdin_getc.c
+setstdin_read: setstdin_read.c
 
 clean:
-	rm -f sock hello rand realloc uid sleep time
+	rm -f sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+#This script is designed to be used with cmake builds.
+
 export PREENY_DEBUG=1
 export PREENY_INFO=1
 export PREENY_ERROR=1
@@ -21,3 +24,8 @@ echo "TEST" | LD_PRELOAD=lib/libdesock.so ./bin/test_sock
 
 # Canary
 LD_PRELOAD=lib/libgetcanary.so ./bin/test_hello
+
+# SetSTDIN
+LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_fread
+LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_getc
+LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_read

--- a/test/setstdin_fread.c
+++ b/test/setstdin_fread.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+int main() {
+	char buffer[1000];
+	int amount_read;
+	int fd;
+	int amount_to_read = 1;
+	char separator[] = "|";
+
+	fd = fileno(stdin);
+	while (amount_read = fread(buffer, sizeof(char), amount_to_read, stdin))
+	{
+		if (amount_read == -1)
+		{
+			perror("error reading");
+			return EXIT_FAILURE;
+		}
+
+		if (fwrite(buffer, sizeof(char), amount_read, stdout) == -1)
+		{
+			perror("error writing");
+			return EXIT_FAILURE;
+		}
+
+		if (fwrite(separator, sizeof(char), strlen(separator), stdout) == -1)
+		{
+			perror("error writing");
+			return EXIT_FAILURE;
+		}
+
+		amount_to_read++;
+		if (amount_to_read > sizeof(buffer))
+			 amount_to_read = sizeof(buffer);
+	}
+	return EXIT_SUCCESS;
+}
+

--- a/test/setstdin_getc.c
+++ b/test/setstdin_getc.c
@@ -1,0 +1,27 @@
+#include<stdio.h>
+
+int main()
+{
+	int c;
+	char separator = '|';
+	while (1)
+	{
+		c = fgetc(stdin);
+		if (c == EOF)
+			break;
+		putchar(c);
+		putchar(separator);
+
+		c = getc(stdin);
+		if (c == EOF)
+			break;
+		putchar(c);
+		putchar(separator);
+
+		c = getchar();
+		if (c == EOF)
+			break;
+		putchar(c);
+		putchar(separator);
+	}
+}

--- a/test/setstdin_read.c
+++ b/test/setstdin_read.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+int main() {
+	char buffer[1000];
+	int amount_read;
+	int fd;
+	int amount_to_read = 1;
+	char separator[] = "|";
+
+	fd = fileno(stdin);
+	while (amount_read = read(fd, buffer, amount_to_read))
+	{
+		if (amount_read == -1)
+		{
+			perror("error reading");
+			return EXIT_FAILURE;
+		}
+
+		if (fwrite(buffer, sizeof(char), amount_read, stdout) == -1)
+		{
+			perror("error writing");
+			return EXIT_FAILURE;
+		}
+
+		if (fwrite(separator, sizeof(char), strlen(separator), stdout) == -1)
+		{
+			perror("error writing");
+			return EXIT_FAILURE;
+		}
+
+		amount_to_read++;
+		if (amount_to_read > sizeof(buffer))
+			 amount_to_read = sizeof(buffer);
+	}
+	return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
setstdin a library that allow to provide binary with alternative STDIN data by substituting `read`, `fread`, `fgetc`, `getc` and `getchar` calls