### PR TITLE
Add nowrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(setcanary common-preeny dl)
 add_library(setstdin SHARED src/setstdin.c)
 target_link_libraries(setstdin common-preeny dl)
 
+# nowrite
+add_library(nowrite SHARED src/nowrite.c)
+target_link_libraries(nowrite common-preeny dl)
 
 # Tests
 add_executable(test_hello test/hello.c)
@@ -88,6 +91,7 @@ add_executable(test_uid test/uid.c)
 add_executable(test_setstdin_read  test/setstdin_read.c)
 add_executable(test_setstdin_fread test/setstdin_fread.c)
 add_executable(test_setstdin_getc  test/setstdin_getc.c)
+add_executable(test_nowrite test/nowrite.c)
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Preeny has the following modules:
 | getcanary | Dumps the canary on program startup (x86 and amd64 only at the moment). |
 | setcanary | Overwrites the canary with a user-provided one on program startup (amd64-only at the moment). |
 | setstdin  | Sets user defined STDIN data instead of real one, overriding `read`, `fread`, `fgetc`, `getc` and `getchar` calls. Read [here](#stdin_substitution) for more info |
+| nowrite | Forces open() to open files in readonly mode. Downgrading from readwrite or writeonly mode, and taking care of append, mktemp and other write-related flags as well |
 
 ## Building
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,6 +66,7 @@ crazyrealloc.so: CFLAGS+=-ldl
 patch.so: CFLAGS+=-ldl -lini_config
 eofkiller.so: CFLAGS+=-ldl
 setstdin.so: CFLAGS+=-ldl
+nowrite.so: CFLAGS+=-ldl
 
 %.so: %.c $(COMMON_DEPS)
 	$(CC) $^ -o $@ -shared -fPIC $(CFLAGS)

--- a/src/nowrite.c
+++ b/src/nowrite.c
@@ -1,0 +1,22 @@
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <dlfcn.h>
+
+int (*original_open)(const char *pathname, int flags, ...);
+
+__attribute__((constructor)) void preeny_nowrite()
+{
+	original_open = dlsym(RTLD_NEXT, "open");
+}
+
+int open(const char *pathname, int flags, ...) {
+	// Strip write-related flags & force readonly flag
+	flags &= ~(O_WRONLY|O_RDWR|O_CLOEXEC|O_CREAT|O_DIRECTORY|O_EXCL|O_NOCTTY|O_NOFOLLOW|O_TMPFILE|O_TRUNC);
+	flags |= O_RDONLY;
+
+	return original_open(pathname, flags);
+}
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-all: sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read
+all: sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read nowrite
 
 sock: sock.c
 hello: hello.c
@@ -12,6 +12,7 @@ time: time.c
 setstdin_fread: setstdin_fread.c
 setstdin_getc: setstdin_getc.c
 setstdin_read: setstdin_read.c
+nowrite: nowrite.c
 
 clean:
-	rm -f sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read
+	rm -f sock hello rand realloc uid sleep time setstdin_fread setstdin_getc setstdin_read nowrite

--- a/test/nowrite.c
+++ b/test/nowrite.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main()
+{
+	char buffer[1024];
+
+	// readonly
+	FILE *fRO = open("nowrite.c", O_RDONLY);
+	assert(read(fRO, buffer, 1024) > 0);
+	close(fRO);
+
+	// writeonly
+	FILE *fWO = open("nowrite.c", O_WRONLY);
+	assert(write(fWO, buffer, 1024) == -1);
+	close(fWO);
+
+	// read/write
+	FILE *fRW = open("nowrite.c", O_RDWR);
+	assert(read(fRW, buffer, 1024) > 0);
+	assert(write(fRW, buffer, 1024) == -1);
+	close(fRW);
+
+	// read + create
+	FILE *fCR = open("nowrite.ccc", O_WRONLY|O_CREAT);
+	assert(write(fCR, buffer, 1024) == -1);
+	close(fCR);
+
+	// tempfile
+	FILE *fTM = open("nowrite.c", O_WRONLY|O_TMPFILE);
+	assert(write(fTM, buffer, 1024) == -1);
+	close(fTM);
+}

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -29,3 +29,6 @@ LD_PRELOAD=lib/libgetcanary.so ./bin/test_hello
 LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_fread
 LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_getc
 LD_PRELOAD=lib/libsetstdin.so ./bin/test_setstdin_read
+
+# nowrite
+LD_PRELOAD=lib/libnowrite.so ./bin/test_nowrite


### PR DESCRIPTION
Forces `open` to open files in readonly mode. This prevents chaos when fuzzing binaries that unpack archives.
Binaries may still modify the FS with `unlink`/`mkdir`/... but open is a good start I guess :stuck_out_tongue_winking_eye: 
